### PR TITLE
Preston/feature/item odp

### DIFF
--- a/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
@@ -1,6 +1,8 @@
 package com.swagteam360.dungeonadventure.controller;
 
+import com.swagteam360.dungeonadventure.model.Item;
 import com.swagteam360.dungeonadventure.utility.GUIUtils;
+import java.util.List;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -26,13 +28,14 @@ public class InventoryController {
     public ListView<String> inventoryList; //FIXME use special ItemView class?
 
     @FXML
-    public void initialize() {
-        // Register observer with the GameManager
-        //GameManager.getInstance().addPCL(this);
-        System.out.println("TEST");
+    public Button btnBuff;
 
-        String[] test = {"item1", "item2"};
-        inventoryList.getItems().addAll(test);
+
+    @FXML
+    public void initialize() {
+        // disable the button if nothing is selected.
+        btnBuff.disableProperty()
+                .bind(inventoryList.getSelectionModel().selectedItemProperty().isNull());
     }
 
     /**
@@ -48,5 +51,11 @@ public class InventoryController {
         final FXMLLoader loader = new FXMLLoader(getClass()
                 .getResource("/com/swagteam360/dungeonadventure/game-view.fxml"));
         GUIUtils.switchScene(theActionEvent, loader);
+    }
+
+    void setInventoryList(final List<Item> theList) {
+        for (Item x : theList) {
+            inventoryList.getItems().add(x.getName());
+        }
     }
 }

--- a/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
@@ -2,7 +2,11 @@ package com.swagteam360.dungeonadventure.controller;
 
 import com.swagteam360.dungeonadventure.model.Item;
 import com.swagteam360.dungeonadventure.utility.GUIUtils;
+import com.swagteam360.dungeonadventure.view.InventoryCellFactory;
 import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
@@ -25,10 +29,18 @@ public class InventoryController {
     public Button btnBackToGameView;
 
     @FXML
-    public ListView<String> inventoryList; //FIXME use special ItemView class?
+    public ListView<Item> inventoryList; //FIXME use special ItemView class?
 
     @FXML
     public Button btnBuff;
+
+    /**
+     * Hold inventory items in s special JavaFX List. The ListView
+     * will observe this list and update the interface.
+     */
+    private final ObservableList<Item> myObservableItems = FXCollections.observableArrayList();
+
+    public InventoryCellFactory myCellFactory = new InventoryCellFactory();
 
 
     @FXML
@@ -36,6 +48,11 @@ public class InventoryController {
         // disable the button if nothing is selected.
         btnBuff.disableProperty()
                 .bind(inventoryList.getSelectionModel().selectedItemProperty().isNull());
+        // Tell the inventory list which list to observe
+        inventoryList.setItems(myObservableItems);
+        // Set the cell factory so that when the list is built, it is displayed
+        // in a certain way as specified in the cell factory.
+        inventoryList.setCellFactory(myCellFactory);
     }
 
     /**
@@ -54,8 +71,6 @@ public class InventoryController {
     }
 
     void setInventoryList(final List<Item> theList) {
-        for (Item x : theList) {
-            inventoryList.getItems().add(x.getName());
-        }
+        myObservableItems.addAll(theList);
     }
 }

--- a/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/controller/InventoryController.java
@@ -70,6 +70,16 @@ public class InventoryController {
         GUIUtils.switchScene(theActionEvent, loader);
     }
 
+    @FXML
+    private void onBuffClick() {
+        final Item selected = inventoryList.getSelectionModel().getSelectedItem();
+        if (selected != null) {
+            System.out.println(selected.buff());
+        } else {
+            btnBuff.disableProperty().setValue(true);
+        }
+    }
+
     void setInventoryList(final List<Item> theList) {
         myObservableItems.addAll(theList);
     }

--- a/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
@@ -265,6 +265,7 @@ public class GameManager {
         if (myCurrentRoom.hasItems()) {
             List<Item> roomItems = myCurrentRoom.collectAllItems();
             myHero.addToInventory(roomItems);
+            myPCS.firePropertyChange("INVENTORY_CHANGE", null, myHero.getInventory());
         }
 
         // Check if we are at the exit room of the dungeon

--- a/src/main/java/com/swagteam360/dungeonadventure/model/HealthPotion.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/HealthPotion.java
@@ -13,6 +13,8 @@ package com.swagteam360.dungeonadventure.model;
  */
 public class HealthPotion implements Item {
 
+    private static final String NAME = "Health Potion";
+
     /**
      * Represents the number of health points (HP) that this health potion can restore.
      * This value is immutable and is assigned during the instantiation of the HealthPotion object.
@@ -37,6 +39,11 @@ public class HealthPotion implements Item {
     @Override
     public String buff() {
         return "You gain " + myHealAmount + " HP!";
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
     /**

--- a/src/main/java/com/swagteam360/dungeonadventure/model/Item.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/Item.java
@@ -23,4 +23,10 @@ public interface Item {
      */
     String buff();
 
+    /**
+     * Get the name of the potion.
+     * @return String name of the potion
+     */
+    String getName();
+
 }

--- a/src/main/java/com/swagteam360/dungeonadventure/model/VisionPotion.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/VisionPotion.java
@@ -14,6 +14,8 @@ package com.swagteam360.dungeonadventure.model;
  */
 public class VisionPotion implements Item {
 
+    private static final String NAME = "Vision Potion";
+
     // This class will eventually tie into the game logic to provide
     // enhanced vision of the surrounding area. Come back later.
 
@@ -33,6 +35,11 @@ public class VisionPotion implements Item {
     @Override
     public String buff() {
         return "You gain vision of the surrounding area!";
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
     }
 
 }

--- a/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
@@ -1,0 +1,24 @@
+package com.swagteam360.dungeonadventure.view;
+
+import javafx.scene.control.ListView;
+import javafx.util.Callback;
+import javafx.scene.control.ListCell;
+import com.swagteam360.dungeonadventure.model.Item;
+
+public class InventoryCellFactory implements Callback<ListView<Item>, ListCell<Item>> {
+    @Override
+    public ListCell<Item> call(ListView<Item> theListView) {
+        return new ListCell<Item>() {
+            @Override
+            public void updateItem(Item theItem, boolean empty) {
+                super.updateItem(theItem, empty);
+
+                if (empty) {
+                    setText(null);
+                } else {
+                    setText(theItem.getName());
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
@@ -4,7 +4,7 @@ import javafx.scene.control.ListView;
 import javafx.util.Callback;
 import javafx.scene.control.ListCell;
 import com.swagteam360.dungeonadventure.model.Item;
-
+// PROBABLY OLD AND IRRELEVANT
 public class InventoryCellFactory implements Callback<ListView<Item>, ListCell<Item>> {
     @Override
     public ListCell<Item> call(ListView<Item> theListView) {

--- a/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/view/InventoryCellFactory.java
@@ -4,7 +4,7 @@ import javafx.scene.control.ListView;
 import javafx.util.Callback;
 import javafx.scene.control.ListCell;
 import com.swagteam360.dungeonadventure.model.Item;
-// PROBABLY OLD AND IRRELEVANT
+
 public class InventoryCellFactory implements Callback<ListView<Item>, ListCell<Item>> {
     @Override
     public ListCell<Item> call(ListView<Item> theListView) {

--- a/src/main/resources/com/swagteam360/dungeonadventure/inventory-view.fxml
+++ b/src/main/resources/com/swagteam360/dungeonadventure/inventory-view.fxml
@@ -2,10 +2,16 @@
 
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
 
 <AnchorPane prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.swagteam360.dungeonadventure.controller.InventoryController">
    <children>
       <Button fx:id="btnBackToGameView" layoutX="14.0" layoutY="361.0" mnemonicParsing="false" onAction="#goBackToGameView" text="Back" />
       <ListView fx:id="inventoryList" layoutX="14.0" layoutY="14.0" prefHeight="343.0" prefWidth="573.0" />
+      <Button fx:id="btnBuff" layoutX="189.0" layoutY="360.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="224.0" text="BUFF" textAlignment="CENTER">
+         <font>
+            <Font name="System Bold" size="12.0" />
+         </font>
+      </Button>
    </children>
 </AnchorPane>

--- a/src/main/resources/com/swagteam360/dungeonadventure/inventory-view.fxml
+++ b/src/main/resources/com/swagteam360/dungeonadventure/inventory-view.fxml
@@ -8,7 +8,7 @@
    <children>
       <Button fx:id="btnBackToGameView" layoutX="14.0" layoutY="361.0" mnemonicParsing="false" onAction="#goBackToGameView" text="Back" />
       <ListView fx:id="inventoryList" layoutX="14.0" layoutY="14.0" prefHeight="343.0" prefWidth="573.0" />
-      <Button fx:id="btnBuff" layoutX="189.0" layoutY="360.0" mnemonicParsing="false" prefHeight="26.0" prefWidth="224.0" text="BUFF" textAlignment="CENTER">
+      <Button fx:id="btnBuff" layoutX="189.0" layoutY="360.0" mnemonicParsing="false" onAction="#onBuffClick" prefHeight="26.0" prefWidth="224.0" text="BUFF" textAlignment="CENTER">
          <font>
             <Font name="System Bold" size="12.0" />
          </font>


### PR DESCRIPTION
## Connecting the Inventory Backend With the Frontend
Using the Observer Design Pattern via the PropertyChangeListeners that Jonathan implemented, I was able to connect changes in the inventory with the frontend. When a user picks up a potion, it is reflected in the inventory.
- Inventory controller code is in its own "InventoryController" class
- I added a line to the goToInventoryView() method in GameViewController to set the inventory list contents after receiving updates (it won't work in the InventoryController class because that class isn't instantiated until after the inventory is open, but the GameViewController stays active during active gameplay).
- Added an unloadObserver() method because the backend was still sending updates to the "dead" instances of GameViewController after switching to and from the inventory.
- A bug exists where the inventory will become empty if you switch to it a second time (a JavaFX gotcha regarding controller instances). I think I'll just need to send additional updates upon PropertyChangeListener registration, but I'll handle that after this PR gets handled.