### PR TITLE
Preston/fix/pillar collection

### DIFF
--- a/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
@@ -408,7 +408,7 @@ public final class GameManager {
         if (myCurrentRoom.hasMonster()) {
             final Monster monster = myCurrentRoom.getMonster();
             myPCS.firePropertyChange("Fight", null, monster);
-            return;
+            return; // fixme this is a problem - you won't be able to collect pillars if a monster exists in the room
         }
 
         if (myCurrentRoom.hasPit()) {

--- a/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
@@ -421,7 +421,7 @@ public final class GameManager {
             myPCS.firePropertyChange("Dead", null, myHero);
         }
 
-        if (myCurrentRoom.hasItems()) {
+        if (myCurrentRoom.hasItems() || myCurrentRoom.hasPillar()) {
             List<Item> roomItems = myCurrentRoom.collectAllItems();
             myHero.addToInventory(roomItems);
             myPCS.firePropertyChange("INVENTORY_CHANGE", null, myHero.getInventory());

--- a/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/GameManager.java
@@ -407,8 +407,10 @@ public final class GameManager {
 
         if (myCurrentRoom.hasMonster()) {
             final Monster monster = myCurrentRoom.getMonster();
-            myPCS.firePropertyChange("Fight", null, monster);
-            return; // fixme this is a problem - you won't be able to collect pillars if a monster exists in the room
+            if (monster.getHP() > 0) {
+                myPCS.firePropertyChange("Fight", null, monster);
+                return;
+            }
         }
 
         if (myCurrentRoom.hasPit()) {

--- a/src/main/java/com/swagteam360/dungeonadventure/model/Room.java
+++ b/src/main/java/com/swagteam360/dungeonadventure/model/Room.java
@@ -21,8 +21,15 @@ public class Room implements Cell, IRoom, Serializable {
      */
     private final List<Item> myItems;
 
+    /**
+     * Reference to the room's pillar, if applicable.
+     */
     private Pillar myPillar;
-    private boolean myPit = false; //FIXME
+
+    /**
+     * States whether the room has a pit.
+     */
+    private boolean myPit = false;
 
     /**
      * Specify whether the room is an entrance,
@@ -305,9 +312,16 @@ public class Room implements Cell, IRoom, Serializable {
     @Override
     public List<Item> collectAllItems() {
         //TODO implement checks to ensure that items aren't collected during certain conditions
-        final List<Item> roomItems = new ArrayList<>(myItems); // create a copy of the list
-        myItems.clear(); // clear the list for the room so that items cannot be collected again
-        return roomItems; // return the list of items to the player
+        final List<Item> roomItems = new ArrayList<>(myItems); // CREATE a COPY of the list
+
+        // ADD a pillar if a pillar exists in the room
+        if (myPillar != null) {
+            roomItems.add(myPillar);
+            myPillar = null; // REMOVE pillar
+        }
+
+        myItems.clear(); // CLEAR the list for the room so that items cannot be collected again
+        return roomItems; // RETURN the list of items to the player
     }
 
     @Override


### PR DESCRIPTION
## Collect Pillars
The player can now collect pillars properly.

Note that in GameManager on lines 408-414, I added a conditional statement so that battles only occur if the monster is alive. If the monster is not alive (HP <= 0), then no fight occurs, or at least I think that's how it works. Prior to this change, player's would not be able to collect items from rooms with monsters because the return statement would skip passed those checks.

Note that this bug may still partially exist where a player has to exit and re-enter the room to collect items (I haven't tested this). This may require fixing the battle system.